### PR TITLE
Auto update parquets

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,8 @@ def get_batch(symbol, interval='1m', start_time=0, limit=1000):
         'limit': limit
     }
     try:
-        response = requests.get(f'{API_BASE}klines', params)
+        # timeout should also be given as a parameter to the fonction
+        response = requests.get(f'{API_BASE}klines', params, timeout=30)
     except requests.exceptions.ConnectionError:
         print('Connection error, Cooling down for 5 mins...')
         time.sleep(5 * 60)

--- a/main.py
+++ b/main.py
@@ -78,9 +78,20 @@ def get_batch(symbol, interval='1m', start_time=0, limit=1000):
     try:
         response = requests.get(f'{API_BASE}klines', params)
     except requests.exceptions.ConnectionError:
-        print('Cooling down for 5 mins...')
+        print('Connection error, Cooling down for 5 mins...')
         time.sleep(5 * 60)
         return get_batch(symbol, interval, start_time, limit)
+    
+    except requests.exceptions.Timeout:
+        print('Timeout, Cooling down for 5 min...')
+        time.sleep(5 * 60)
+        return get_batch(symbol, interval, start_time, limit)
+    
+    except requests.exceptions.ConnectionResetError:
+        print('Connection reset by peer, Cooling down for 5 min...')
+        time.sleep(5 * 60)
+        return get_batch(symbol, interval, start_time, limit)
+
     if response.status_code == 200:
         return pd.DataFrame(response.json(), columns=LABELS)
     print(f'Got erroneous response back: {response}')

--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ def get_batch(symbol, interval='1m', start_time=0, limit=1000):
         'limit': limit
     }
     try:
-        # timeout should also be given as a parameter to the fonction
+        # timeout should also be given as a parameter to the function
         response = requests.get(f'{API_BASE}klines', params, timeout=30)
     except requests.exceptions.ConnectionError:
         print('Connection error, Cooling down for 5 mins...')

--- a/main.py
+++ b/main.py
@@ -31,9 +31,9 @@ BATCH_SIZE = 1000  # Number of candles to ask for in each API request.
 SHAVE_OFF_TODAY = False  # Whether to shave off candles after last midnight to equalize end-time of all datasets.
 CIRCUMVENT_CSV = True  # Whether to use the parquet files directly when updating data.
 UPLOAD_TO_KAGGLE = False  # Whether to upload the parquet files to kaggle after updating.
-
 COMPRESSED_PATH = r'C:\Users\magla\Documents\Datasets\binance_pairs'
 CSV_PATH = 'data'
+
 API_BASE = 'https://api.binance.com/api/v3/'
 
 LABELS = [
@@ -158,8 +158,9 @@ def gather_new_candles(base, quote, last_timestamp, interval='1m'):
 
         if bar is not None:
             time_covered = datetime.fromtimestamp(last_timestamp / 1000) - start_datetime
-            bar.max_value = int((datetime.now() - start_datetime).total_seconds()/60)
-            bar.update(int(time_covered.total_seconds()/60))
+            minutes_covered = int(time_covered.total_seconds()/60)
+            bar.max_value = max(int((datetime.now() - start_datetime).total_seconds()/60), minutes_covered)
+            bar.update(minutes_covered)
     if bar is not None:
         bar.finish()
     if in_pycharm: time.sleep(0.2)

--- a/main.py
+++ b/main.py
@@ -25,13 +25,14 @@ import pyarrow.parquet as pq
 import requests
 import pandas as pd
 import preprocessing as pp
+in_pycharm = "PYCHARM_HOSTED" in os.environ
 
 BATCH_SIZE = 1000  # Number of candles to ask for in each API request.
 SHAVE_OFF_TODAY = False  # Whether to shave off candles after last midnight to equalize end-time of all datasets.
 CIRCUMVENT_CSV = True  # Whether to use the parquet files directly when updating data.
 UPLOAD_TO_KAGGLE = False  # Whether to upload the parquet files to kaggle after updating.
 
-COMPRESSED_PATH = 'compressed'
+COMPRESSED_PATH = r'C:\Users\magla\Documents\Datasets\binance_pairs'
 CSV_PATH = 'data'
 API_BASE = 'https://api.binance.com/api/v3/'
 
@@ -150,14 +151,18 @@ def gather_new_candles(base, quote, last_timestamp, interval='1m'):
             missing_data_timedelta = datetime.now() - start_datetime
             total_minutes_of_data = int(missing_data_timedelta.total_seconds()/60)
             print(f"Will fetch {missing_data_timedelta} ({total_minutes_of_data} minutes) worth of candles.")
+            if in_pycharm: time.sleep(0.2)
             first_read = False
             if total_minutes_of_data >= BATCH_SIZE*2:
                 bar = ProgressBar(max_value=total_minutes_of_data)
 
         if bar is not None:
             time_covered = datetime.fromtimestamp(last_timestamp / 1000) - start_datetime
+            bar.max_value = int((datetime.now() - start_datetime).total_seconds()/60)
             bar.update(int(time_covered.total_seconds()/60))
-
+    if bar is not None:
+        bar.finish()
+    if in_pycharm: time.sleep(0.2)
     return batches
 
 

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -2,7 +2,8 @@ import os
 from datetime import date
 import pyarrow.parquet as pq
 import pandas as pd
-from main import SHAVE_OFF_TODAY
+from main import SHAVE_OFF_TODAY, CSV_PATH, COMPRESSED_PATH
+
 
 def set_dtypes(df):
     """
@@ -76,7 +77,7 @@ def quick_clean(df):
 
 
 def append_raw_to_parquet(df, full_path):
-    """takes raw df and writes a parquet to disk"""
+    """Takes raw df and appends it to an existing parquet file. If the file does not exist, it is created."""
     df = polish_df(df)
     try:
         df = pd.concat([pq.read_pandas(full_path).to_pandas(), df])
@@ -85,7 +86,8 @@ def append_raw_to_parquet(df, full_path):
     df.to_parquet(full_path)
 
 def write_raw_to_parquet(df, full_path):
-    """takes raw df and writes a parquet to disk"""
+    """Takes raw df and writes it to an existing parquet file, overwriting existin data. If the file does not exist,
+    it is created."""
     df = polish_df(df)
     df.to_parquet(full_path)
 
@@ -113,10 +115,10 @@ def groom_data(dirname='data'):
             quick_clean(pd.read_csv(full_path)).to_csv(full_path)
 
 
-def compress_data(dirname='data'):
+def compress_data(dirname=f'{CSV_PATH}'):
     """go through data folder and rewrite csv files to parquets"""
 
-    os.makedirs('compressed', exist_ok=True)
+    os.makedirs(f'{COMPRESSED_PATH}', exist_ok=True)
     for filename in os.listdir(dirname):
         if filename.endswith('.csv'):
             full_path = f'{dirname}/{filename}'
@@ -124,5 +126,5 @@ def compress_data(dirname='data'):
             df = pd.read_csv(full_path)
 
             new_filename = filename.replace('.csv', '.parquet')
-            new_full_path = f'compressed/{new_filename}'
+            new_full_path = f'{COMPRESSED_PATH}/{new_filename}'
             write_raw_to_parquet(df, new_full_path)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -2,7 +2,6 @@ import os
 from datetime import date
 import pyarrow.parquet as pq
 import pandas as pd
-from main import SHAVE_OFF_TODAY, CSV_PATH, COMPRESSED_PATH
 
 
 def set_dtypes(df):
@@ -76,22 +75,22 @@ def quick_clean(df):
     return df
 
 
-def append_raw_to_parquet(df, full_path):
+def append_raw_to_parquet(df, full_path, limit_to_today=True):
     """Takes raw df and appends it to an existing parquet file. If the file does not exist, it is created."""
-    df = polish_df(df)
+    df = polish_df(df, limit_to_today)
     try:
         df = pd.concat([pq.read_pandas(full_path).to_pandas(), df])
     except OSError:
         pass
     df.to_parquet(full_path)
 
-def write_raw_to_parquet(df, full_path):
+def write_raw_to_parquet(df, full_path, limit_to_today=True):
     """Takes raw df and writes it to an existing parquet file, overwriting existin data. If the file does not exist,
     it is created."""
-    df = polish_df(df)
+    df = polish_df(df, limit_to_today)
     df.to_parquet(full_path)
 
-def polish_df(df):
+def polish_df(df, limit_to_today=True):
     # some candlesticks do not span a full minute
     # these points are not reliable and thus filtered
     df = df[~(df['open_time'] - df['close_time'] != -59999)]
@@ -102,29 +101,29 @@ def polish_df(df):
     df = set_dtypes_compressed(df)
 
     # give all pairs the same nice cut-off
-    if SHAVE_OFF_TODAY:
+    if limit_to_today:
         df = df[df.index < str(date.today())]
     return df
 
-def groom_data(dirname='data'):
+def groom_data(csv_dir):
     """go through data folder and perform a quick clean on all csv files"""
 
-    for filename in os.listdir(dirname):
+    for filename in os.listdir(csv_dir):
         if filename.endswith('.csv'):
-            full_path = f'{dirname}/{filename}'
+            full_path = csv_dir + f'/{filename}'
             quick_clean(pd.read_csv(full_path)).to_csv(full_path)
 
 
-def compress_data(dirname=f'{CSV_PATH}'):
+def compress_data(csv_dir, parquet_path):
     """go through data folder and rewrite csv files to parquets"""
 
-    os.makedirs(f'{COMPRESSED_PATH}', exist_ok=True)
-    for filename in os.listdir(dirname):
+    os.makedirs(parquet_path, exist_ok=True)
+    for filename in os.listdir(csv_dir):
         if filename.endswith('.csv'):
-            full_path = f'{dirname}/{filename}'
+            full_path = f'{csv_dir}/{filename}'
 
             df = pd.read_csv(full_path)
 
             new_filename = filename.replace('.csv', '.parquet')
-            new_full_path = f'{COMPRESSED_PATH}/{new_filename}'
+            new_full_path = parquet_path + f'/{new_filename}'
             write_raw_to_parquet(df, new_full_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pandas
 pyarrow
 kaggle
+progressbar2


### PR DESCRIPTION
This pull request adds new functionality:

- Optional direct update of parquet files
Parquet files can be updated directly without the need for intermediate CSV files. This makes it much more convenient for users who have downloaded the parquet files from kaggle and wish to keep the up to date. 
- Improved output
A progressbar is displayed during the fetching of candles, showing the user how many candles will be retrieved, and how long it is expected to take.
![image](https://user-images.githubusercontent.com/15835242/110095597-5f787780-7d9d-11eb-9599-1d2b934d0013.png)

- Additional user settings
The user can set global variables on the top of Main.py to control how the script behaves. 
![image](https://user-images.githubusercontent.com/15835242/110095710-7ae38280-7d9d-11eb-99c8-74de7fc2fa74.png)

The code has also been refactored in order to more easily implement the changes listed above. The functionality of the code has not been changed, and the script can be used just as before this pull request.